### PR TITLE
home: add messaging home modules

### DIFF
--- a/home-configurations/cassiterite/djacu/default.nix
+++ b/home-configurations/cassiterite/djacu/default.nix
@@ -8,6 +8,8 @@
       theonecfg.users.djacu.enable = true;
       theonecfg.users.djacu.dev.enable = true;
       theonecfg.users.djacu.desktop.enable = true;
+
+      theonecfg.home.programs.messaging.enable = true;
     }
   ];
 }

--- a/home-configurations/malachite/djacu/default.nix
+++ b/home-configurations/malachite/djacu/default.nix
@@ -8,6 +8,8 @@
       theonecfg.users.djacu.enable = true;
       theonecfg.users.djacu.dev.enable = true;
       theonecfg.users.djacu.desktop.enable = true;
+
+      theonecfg.home.programs.messaging.enable = true;
     }
   ];
 }

--- a/home-modules/programs/default.nix
+++ b/home-modules/programs/default.nix
@@ -3,6 +3,7 @@
   imports = [
     ./fd.nix
     ./kitty.nix
+    ./messaging.nix
     ./nixvimcfg.nix
     ./tmux.nix
   ];

--- a/home-modules/programs/messaging.nix
+++ b/home-modules/programs/messaging.nix
@@ -1,0 +1,25 @@
+{
+  lib,
+  config,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.theonecfg.home.programs.messaging;
+in
+{
+  options.theonecfg.home.programs.messaging.enable = lib.mkEnableOption "messaging config";
+
+  config = lib.mkIf cfg.enable {
+
+    home.packages = [
+      pkgs.discord
+      pkgs.element-desktop-wayland
+      pkgs.signal-desktop
+      pkgs.whatsapp-for-linux
+    ];
+
+    nixpkgs.config.allowUnfree = true;
+
+  };
+}


### PR DESCRIPTION
Added messaging home module which enables signal, whatsapp, discord, and element. Enabled for cassiterite and malachite home configurations.