### PR TITLE
treewide: nixos 25.05 upgrade

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,27 +1,5 @@
 {
   "nodes": {
-    "devshell": {
-      "inputs": {
-        "nixpkgs": [
-          "nixvimcfg",
-          "nixvim",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1728330715,
-        "narHash": "sha256-xRJ2nPOXb//u1jaBnDP56M7v5ldavjbtR6lfGqSvcKg=",
-        "owner": "numtide",
-        "repo": "devshell",
-        "rev": "dd6b80932022cea34a019e2bb32f6fa9e494dfef",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "devshell",
-        "type": "github"
-      }
-    },
     "disko": {
       "inputs": {
         "nixpkgs": [
@@ -29,31 +7,17 @@
         ]
       },
       "locked": {
-        "lastModified": 1726842196,
-        "narHash": "sha256-u9h03JQUuQJ607xmti9F9Eh6E96kKUAGP+aXWgwm70o=",
+        "lastModified": 1753140376,
+        "narHash": "sha256-7lrVrE0jSvZHrxEzvnfHFE/Wkk9DDqb+mYCodI5uuB8=",
         "owner": "nix-community",
         "repo": "disko",
-        "rev": "51994df8ba24d5db5459ccf17b6494643301ad28",
+        "rev": "545aba02960caa78a31bd9a8709a0ad4b6320a5c",
         "type": "github"
       },
       "original": {
         "owner": "nix-community",
         "repo": "disko",
         "type": "github"
-      }
-    },
-    "flake-compat": {
-      "locked": {
-        "lastModified": 1696426674,
-        "narHash": "sha256-kvjfFW7WAETZlt09AgDn1MrtKzP7t90Vf7vypd3OL1U=",
-        "rev": "0f9255e01c2351cc7d116c072cb317785dd33b33",
-        "revCount": 57,
-        "type": "tarball",
-        "url": "https://api.flakehub.com/f/pinned/edolstra/flake-compat/1.0.1/018afb31-abd1-7bff-a5e4-cff7e18efb7a/source.tar.gz"
-      },
-      "original": {
-        "type": "tarball",
-        "url": "https://flakehub.com/f/edolstra/flake-compat/1.tar.gz"
       }
     },
     "flake-parts": {
@@ -65,11 +29,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1727826117,
-        "narHash": "sha256-K5ZLCyfO/Zj9mPFldf3iwS6oZStJcU4tSpiXTMYaaL0=",
+        "lastModified": 1738453229,
+        "narHash": "sha256-7H9XgNiGLKN1G1CgRh0vUL4AheZSYzPm+zmZ7vxbJdo=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "3d04084d54bedc3d6b8b736c70ef449225c361b1",
+        "rev": "32ea77a06711b758da0ad9bd6a844c5740a87abd",
         "type": "github"
       },
       "original": {
@@ -78,117 +42,24 @@
         "type": "github"
       }
     },
-    "flake-utils": {
+    "flake-parts_2": {
       "inputs": {
-        "systems": "systems"
-      },
-      "locked": {
-        "lastModified": 1726560853,
-        "narHash": "sha256-X6rJYSESBVr3hBoH0WbKE5KvhPU5bloyZ2L4K60/fPQ=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "c1dfcf08411b08f6b8615f7d8971a2bfa81d5e8a",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
-    "flake-utils_2": {
-      "inputs": {
-        "systems": "systems_2"
-      },
-      "locked": {
-        "lastModified": 1726560853,
-        "narHash": "sha256-X6rJYSESBVr3hBoH0WbKE5KvhPU5bloyZ2L4K60/fPQ=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "c1dfcf08411b08f6b8615f7d8971a2bfa81d5e8a",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
-    "git-hooks": {
-      "inputs": {
-        "flake-compat": [
-          "nixvimcfg",
-          "nixvim",
-          "flake-compat"
-        ],
-        "gitignore": "gitignore",
-        "nixpkgs": [
-          "nixvimcfg",
-          "nixvim",
-          "nixpkgs"
-        ],
-        "nixpkgs-stable": [
-          "nixvimcfg",
-          "nixvim",
+        "nixpkgs-lib": [
+          "nur",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1729104314,
-        "narHash": "sha256-pZRZsq5oCdJt3upZIU4aslS9XwFJ+/nVtALHIciX/BI=",
-        "owner": "cachix",
-        "repo": "git-hooks.nix",
-        "rev": "3c3e88f0f544d6bb54329832616af7eb971b6be6",
-        "type": "github"
-      },
-      "original": {
-        "owner": "cachix",
-        "repo": "git-hooks.nix",
-        "type": "github"
-      }
-    },
-    "gitignore": {
-      "inputs": {
-        "nixpkgs": [
-          "nixvimcfg",
-          "nixvim",
-          "git-hooks",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1709087332,
-        "narHash": "sha256-HG2cCnktfHsKV0s4XW83gU3F57gaTljL9KNSuG6bnQs=",
+        "lastModified": 1733312601,
+        "narHash": "sha256-4pDvzqnegAfRkPwO3wmwBhVi/Sye1mzps0zHWYnP88c=",
         "owner": "hercules-ci",
-        "repo": "gitignore.nix",
-        "rev": "637db329424fd7e46cf4185293b9cc8c88c95394",
+        "repo": "flake-parts",
+        "rev": "205b12d8b7cd4802fbcb8e8ef6a0f1408781a4f9",
         "type": "github"
       },
       "original": {
         "owner": "hercules-ci",
-        "repo": "gitignore.nix",
-        "type": "github"
-      }
-    },
-    "home-manager": {
-      "inputs": {
-        "nixpkgs": [
-          "nixvimcfg",
-          "nixvim",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1729260213,
-        "narHash": "sha256-jAvHoU/1y/yCuXzr2fNF+q6uKmr8Jj2xgAisK4QB9to=",
-        "owner": "nix-community",
-        "repo": "home-manager",
-        "rev": "09a0c0c02953318bf94425738c7061ffdc4cba75",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-community",
-        "repo": "home-manager",
+        "repo": "flake-parts",
         "type": "github"
       }
     },
@@ -199,11 +70,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1726818100,
-        "narHash": "sha256-z2V74f5vXqkN5Q+goFlhbFXY/dNaBAyeLpr2bxu4Eic=",
+        "lastModified": 1726989464,
+        "narHash": "sha256-Vl+WVTJwutXkimwGprnEtXc/s/s8sMuXzqXaspIGlwM=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "1bbc1a5a1f4de7401c92db85b2119ed21bb4139d",
+        "rev": "2f23fa308a7c067e52dfcc30a0758f47043ec176",
         "type": "github"
       },
       "original": {
@@ -220,11 +91,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1744743431,
-        "narHash": "sha256-iyn/WBYDc7OtjSawbegINDe/gIkok888kQxk3aVnkgg=",
+        "lastModified": 1747688870,
+        "narHash": "sha256-ypL9WAZfmJr5V70jEVzqGjjQzF0uCkz+AFQF7n9NmNc=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "c61bfe3ae692f42ce688b5865fac9e0de58e1387",
+        "rev": "d5f1f641b289553927b3801580598d200a501863",
         "type": "github"
       },
       "original": {
@@ -234,50 +105,49 @@
         "type": "github"
       }
     },
-    "impermanence": {
-      "locked": {
-        "lastModified": 1725690722,
-        "narHash": "sha256-4qWg9sNh5g1qPGO6d/GV2ktY+eDikkBTbWSg5/iD2nY=",
-        "owner": "nix-community",
-        "repo": "impermanence",
-        "rev": "63f4d0443e32b0dd7189001ee1894066765d18a5",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-community",
-        "repo": "impermanence",
-        "type": "github"
-      }
-    },
-    "nix-darwin": {
+    "home-manager-2505": {
       "inputs": {
         "nixpkgs": [
-          "nixvimcfg",
-          "nixvim",
-          "nixpkgs"
+          "nixpkgs-2505"
         ]
       },
       "locked": {
-        "lastModified": 1728901530,
-        "narHash": "sha256-I9Qd0LnAsEGHtKE9+uVR0iDFmsijWSy7GT0g3jihG4Q=",
-        "owner": "lnl7",
-        "repo": "nix-darwin",
-        "rev": "a60ac02f9466f85f092e576fd8364dfc4406b5a6",
+        "lastModified": 1756245065,
+        "narHash": "sha256-aAZNbGcWrVRZgWgkQbkabSGcDVRDMgON4BipMy69gvI=",
+        "owner": "nix-community",
+        "repo": "home-manager",
+        "rev": "54b2879ce622d44415e727905925e21b8f833a98",
         "type": "github"
       },
       "original": {
-        "owner": "lnl7",
-        "repo": "nix-darwin",
+        "owner": "nix-community",
+        "ref": "release-25.05",
+        "repo": "home-manager",
+        "type": "github"
+      }
+    },
+    "impermanence": {
+      "locked": {
+        "lastModified": 1737831083,
+        "narHash": "sha256-LJggUHbpyeDvNagTUrdhe/pRVp4pnS6wVKALS782gRI=",
+        "owner": "nix-community",
+        "repo": "impermanence",
+        "rev": "4b3e914cdf97a5b536a889e939fb2fd2b043a170",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "impermanence",
         "type": "github"
       }
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1726724509,
-        "narHash": "sha256-sVeAM1tgVi52S1e29fFBTPUAFSzgQwgLon3CrztXGm8=",
+        "lastModified": 1754564048,
+        "narHash": "sha256-dz303vGuzWjzOPOaYkS9xSW+B93PSAJxvBd6CambXVA=",
         "owner": "nixos",
         "repo": "nixos-hardware",
-        "rev": "10d5e0ecc32984c1bf1a9a46586be3451c42fd94",
+        "rev": "26ed7a0d4b8741fe1ef1ee6fa64453ca056ce113",
         "type": "github"
       },
       "original": {
@@ -288,11 +158,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1729665710,
-        "narHash": "sha256-AlcmCXJZPIlO5dmFzV3V2XF6x/OpNWUV8Y/FMPGd8Z4=",
+        "lastModified": 1739214665,
+        "narHash": "sha256-26L8VAu3/1YRxS8MHgBOyOM8xALdo6N0I04PgorE7UM=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "2768c7d042a37de65bb1b5b3268fc987e534c49d",
+        "rev": "64e75cd44acf21c7933d61d7721e812eac1b5a0a",
         "type": "github"
       },
       "original": {
@@ -304,11 +174,11 @@
     },
     "nixpkgs-2405": {
       "locked": {
-        "lastModified": 1726688310,
-        "narHash": "sha256-Xc9lEtentPCEtxc/F1e6jIZsd4MPDYv4Kugl9WtXlz0=",
+        "lastModified": 1735563628,
+        "narHash": "sha256-OnSAY7XDSx7CtDoqNh8jwVwh4xNL/2HaJxGjryLWzX8=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "dbebdd67a6006bb145d98c8debf9140ac7e651d0",
+        "rev": "b134951a4c9f3c995fd7be05f3243f8ecd65d798",
         "type": "github"
       },
       "original": {
@@ -320,11 +190,11 @@
     },
     "nixpkgs-2411": {
       "locked": {
-        "lastModified": 1744440957,
-        "narHash": "sha256-FHlSkNqFmPxPJvy+6fNLaNeWnF1lZSgqVCl/eWaJRc4=",
+        "lastModified": 1751274312,
+        "narHash": "sha256-/bVBlRpECLVzjV19t5KMdMFWSwKLtb5RyXdjz3LJT+g=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "26d499fc9f1d567283d5d56fcf367edd815dba1d",
+        "rev": "50ab793786d9de88ee30ec4e4c24fb4236fc2674",
         "type": "github"
       },
       "original": {
@@ -334,13 +204,44 @@
         "type": "github"
       }
     },
+    "nixpkgs-2505": {
+      "locked": {
+        "lastModified": 1756217674,
+        "narHash": "sha256-TH1SfSP523QI7kcPiNtMAEuwZR3Jdz0MCDXPs7TS8uo=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "4e7667a90c167f7a81d906e5a75cba4ad8bee620",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-25.05",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-lib": {
+      "locked": {
+        "lastModified": 1754788789,
+        "narHash": "sha256-x2rJ+Ovzq0sCMpgfgGaaqgBSwY+LST+WbZ6TytnT9Rk=",
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "rev": "a73b9c743612e4244d865a2fdee11865283c04e6",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "type": "github"
+      }
+    },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1726745986,
-        "narHash": "sha256-xB35C2fpz7iyNcj9sn0a+wM2C4CQ6DGTn5VUHogstYs=",
+        "lastModified": 1754742523,
+        "narHash": "sha256-mofwjXmhfeAFMHj8heWuVV6pGG0l2aBMH1LO0xCo1Fc=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "268bb5090a3c6ac5e1615b38542a868b52ef8088",
+        "rev": "f86999f8bfef9ff57f7f03c1c5deedc2784fc666",
         "type": "github"
       },
       "original": {
@@ -350,27 +251,57 @@
         "type": "github"
       }
     },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1754725699,
+        "narHash": "sha256-iAcj9T/Y+3DBy2J0N+yF9XQQQ8IEb5swLFzs23CdP88=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "85dbfc7aaf52ecb755f87e577ddbe6dbbdbc1054",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "nixvim": {
       "inputs": {
-        "devshell": "devshell",
-        "flake-compat": "flake-compat",
+        "devshell": [
+          "nixvimcfg"
+        ],
+        "flake-compat": [
+          "nixvimcfg"
+        ],
         "flake-parts": "flake-parts",
-        "git-hooks": "git-hooks",
-        "home-manager": "home-manager",
-        "nix-darwin": "nix-darwin",
+        "git-hooks": [
+          "nixvimcfg"
+        ],
+        "home-manager": [
+          "nixvimcfg"
+        ],
+        "nix-darwin": [
+          "nixvimcfg"
+        ],
         "nixpkgs": [
           "nixvimcfg",
           "nixpkgs"
         ],
-        "nuschtosSearch": "nuschtosSearch",
-        "treefmt-nix": "treefmt-nix"
+        "nuschtosSearch": [
+          "nixvimcfg"
+        ],
+        "treefmt-nix": [
+          "nixvimcfg"
+        ]
       },
       "locked": {
-        "lastModified": 1729532160,
-        "narHash": "sha256-Nxpp4vrnMw9R43iWTfsId8vadk7vQk33duanvIQ3V9w=",
+        "lastModified": 1739353096,
+        "narHash": "sha256-w/T2uYCoq4k6K46GX2CMGWsKfMvcqnxC41LIgnvGifE=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "0562e519ec0e69125c5edc917d41bccb54a534fd",
+        "rev": "78b6f8e1e5b37a7789216e17a96ebc117660f0e7",
         "type": "github"
       },
       "original": {
@@ -381,16 +312,15 @@
     },
     "nixvimcfg": {
       "inputs": {
-        "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs",
         "nixvim": "nixvim"
       },
       "locked": {
-        "lastModified": 1730072854,
-        "narHash": "sha256-B68VROYLyQOXxBnB/3DfCCz0PbI5vdDyl4XDH3XqwCA=",
+        "lastModified": 1739427635,
+        "narHash": "sha256-/at3ZxV6dU9+SKJ5cD6Yh64CfVy3dMsgNhGJcgDtD0E=",
         "owner": "djacu",
         "repo": "nixvimcfg",
-        "rev": "d32a8b72c04623495cf8b50fcba1824c418bd2e4",
+        "rev": "fa86e09a62482673b0b71f8af4c459bf306e8697",
         "type": "github"
       },
       "original": {
@@ -400,40 +330,21 @@
       }
     },
     "nur": {
-      "locked": {
-        "lastModified": 1726885747,
-        "narHash": "sha256-y24Q3wfj3hg2jwkcOoRX6UCTX3nT1Z5g+plrQtHznHU=",
-        "owner": "nix-community",
-        "repo": "nur",
-        "rev": "ee7ba7bc1e6ac987a4de9a910fbd9ce5a98f6b63",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-community",
-        "repo": "nur",
-        "type": "github"
-      }
-    },
-    "nuschtosSearch": {
       "inputs": {
-        "flake-utils": "flake-utils_2",
-        "nixpkgs": [
-          "nixvimcfg",
-          "nixvim",
-          "nixpkgs"
-        ]
+        "flake-parts": "flake-parts_2",
+        "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1728905062,
-        "narHash": "sha256-W/lClt0bRgFRO0WFtytX/LEILpPNq+FOjIfESpkeu5c=",
-        "owner": "NuschtOS",
-        "repo": "search",
-        "rev": "f82d3e1c1c9d1eaeb91878519e2d27b27c66ce84",
+        "lastModified": 1754796447,
+        "narHash": "sha256-Nr9VQAQNRMS1KdMff8pjQKzKhLeTQMU5tYRTAoJn2HI=",
+        "owner": "nix-community",
+        "repo": "nur",
+        "rev": "49b376f0dfde378efa30fa99536dd87792e4d91f",
         "type": "github"
       },
       "original": {
-        "owner": "NuschtOS",
-        "repo": "search",
+        "owner": "nix-community",
+        "repo": "nur",
         "type": "github"
       }
     },
@@ -442,65 +353,16 @@
         "disko": "disko",
         "home-manager-2405": "home-manager-2405",
         "home-manager-2411": "home-manager-2411",
+        "home-manager-2505": "home-manager-2505",
         "impermanence": "impermanence",
         "nixos-hardware": "nixos-hardware",
         "nixpkgs-2405": "nixpkgs-2405",
         "nixpkgs-2411": "nixpkgs-2411",
+        "nixpkgs-2505": "nixpkgs-2505",
+        "nixpkgs-lib": "nixpkgs-lib",
         "nixpkgs-unstable": "nixpkgs-unstable",
         "nixvimcfg": "nixvimcfg",
         "nur": "nur"
-      }
-    },
-    "systems": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
-        "type": "github"
-      }
-    },
-    "systems_2": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
-        "type": "github"
-      }
-    },
-    "treefmt-nix": {
-      "inputs": {
-        "nixpkgs": [
-          "nixvimcfg",
-          "nixvim",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1729242555,
-        "narHash": "sha256-6jWSWxv2crIXmYSEb3LEVsFkCkyVHNllk61X4uhqfCs=",
-        "owner": "numtide",
-        "repo": "treefmt-nix",
-        "rev": "d986489c1c757f6921a48c1439f19bfb9b8ecab5",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "treefmt-nix",
-        "type": "github"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -6,9 +6,13 @@
     home-manager-2405.inputs.nixpkgs.follows = "nixpkgs-2405";
     home-manager-2411.url = "github:nix-community/home-manager/release-24.11";
     home-manager-2411.inputs.nixpkgs.follows = "nixpkgs-2411";
+    home-manager-2505.url = "github:nix-community/home-manager/release-25.05";
+    home-manager-2505.inputs.nixpkgs.follows = "nixpkgs-2505";
     impermanence.url = "github:nix-community/impermanence";
+    nixpkgs-lib.url = "github:nix-community/nixpkgs.lib";
     nixpkgs-2405.url = "github:nixos/nixpkgs/nixos-24.05";
     nixpkgs-2411.url = "github:nixos/nixpkgs/nixos-24.11";
+    nixpkgs-2505.url = "github:nixos/nixpkgs/nixos-25.05";
     nixpkgs-unstable.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
     nixos-hardware.url = "github:nixos/nixos-hardware";
     nixvimcfg.url = "github:djacu/nixvimcfg";

--- a/flake.nix
+++ b/flake.nix
@@ -19,19 +19,15 @@
     nur.url = "github:nix-community/nur";
   };
 
-  outputs =
-    { self, ... }@inputs:
-    {
-      formatter = import ./formatter inputs;
-      homeConfigurations = import ./home-configurations inputs;
-      homeModules = import ./home-modules inputs;
-      legacyPackages = import ./legacy-packages inputs;
-      library = import ./library inputs;
-      nixosConfigurations = import ./nixos-configurations inputs;
-      nixosModules = import ./nixos-modules inputs;
-      overlays = import ./overlays inputs;
-      packages = import ./packages inputs;
-
-      # packages.x86_64-linux.test-vm = self.nixosConfigurations.test-vm.config.system.build.vm;
-    };
+  outputs = inputs: {
+    formatter = import ./formatter inputs;
+    homeConfigurations = import ./home-configurations inputs;
+    homeModules = import ./home-modules inputs;
+    legacyPackages = import ./legacy-packages inputs;
+    library = import ./library inputs;
+    nixosConfigurations = import ./nixos-configurations inputs;
+    nixosModules = import ./nixos-modules inputs;
+    overlays = import ./overlays inputs;
+    packages = import ./packages inputs;
+  };
 }

--- a/home-modules/djacu/dev.nix
+++ b/home-modules/djacu/dev.nix
@@ -20,6 +20,7 @@ in
     programs.ssh.enable = true;
 
     home.packages = with pkgs; [
+
       ansifilter
       as-tree
       bat
@@ -31,6 +32,7 @@ in
       dnsutils
       dt
       file
+      gh
       grex
       gron
       htmlq
@@ -53,6 +55,7 @@ in
       tealdeer
       traceroute
       yj
+      zathura
 
     ];
   };

--- a/nixos-configurations/cassiterite/default.nix
+++ b/nixos-configurations/cassiterite/default.nix
@@ -29,6 +29,8 @@
         boot.supportedFilesystems = [ "zfs" ];
         boot.zfs.devNodes = "/dev/disk/by-id";
 
+        hardware.bluetooth.enable = true;
+
         networking.hostId = "abc0862c";
 
         security.sudo.extraConfig = ''

--- a/nixos-configurations/malachite/default.nix
+++ b/nixos-configurations/malachite/default.nix
@@ -27,6 +27,8 @@
         boot.supportedFilesystems = [ "zfs" ];
         boot.zfs.devNodes = "/dev/disk/by-id";
 
+        hardware.bluetooth.enable = true;
+
         networking.hostId = lib.substring 0 8 (builtins.hashString "sha256" config.networking.hostName);
 
         security.sudo.extraConfig = ''

--- a/nixos-configurations/malachite/default.nix
+++ b/nixos-configurations/malachite/default.nix
@@ -1,5 +1,5 @@
 {
-  release = "2411";
+  release = "2505";
   modules =
     {
       config,
@@ -8,9 +8,6 @@
       pkgs,
       ...
     }:
-    let
-      theonecfgLib = inputs.self.library;
-    in
     {
       imports = [
         ./disko.nix
@@ -23,7 +20,7 @@
         nixpkgs.hostPlatform = "x86_64-linux";
         system.stateVersion = "24.05";
 
-        boot.kernelPackages = theonecfgLib.zfs.latestKernelPackage { inherit config pkgs; };
+        boot.kernelPackages = pkgs.linuxPackages_6_15;
         boot.loader.systemd-boot.enable = true;
         boot.loader.efi.canTouchEfiVariables = true;
         boot.loader.efi.efiSysMountPoint = "/boot";

--- a/nixos-modules/audio.nix
+++ b/nixos-modules/audio.nix
@@ -1,18 +1,43 @@
-{ lib, config, ... }:
+{
+  lib,
+  pkgs,
+  config,
+  ...
+}:
 let
+
+  inherit (lib.modules)
+    mkIf
+    ;
+
+  inherit (lib.options)
+    mkEnableOption
+    ;
+
   cfg = config.theonecfg.audio;
+
 in
 {
-  options.theonecfg.audio.enable = lib.mkEnableOption "audio setup";
+  options.theonecfg.audio.enable = mkEnableOption "audio setup";
 
-  config = lib.mkIf cfg.enable {
-    hardware.bluetooth.enable = true;
-    # hardware.pulseaudio.enable = false;
-    security.rtkit.enable = true;
+  config = mkIf cfg.enable {
+
+    # for pactl
+    environment.systemPackages = with pkgs; [
+      pulseaudio
+      pamixer
+    ];
+
     services.pipewire = {
       enable = true;
       alsa.enable = true;
+      alsa.support32Bit = true;
       pulse.enable = true;
     };
+
+    services.pulseaudio.enable = false;
+
+    security.rtkit.enable = true;
+
   };
 }

--- a/nixos-modules/audio.nix
+++ b/nixos-modules/audio.nix
@@ -7,7 +7,7 @@ in
 
   config = lib.mkIf cfg.enable {
     hardware.bluetooth.enable = true;
-    hardware.pulseaudio.enable = false;
+    # hardware.pulseaudio.enable = false;
     security.rtkit.enable = true;
     services.pipewire = {
       enable = true;

--- a/nixos-modules/common.nix
+++ b/nixos-modules/common.nix
@@ -17,7 +17,7 @@ in
     i18n.defaultLocale = "en_US.UTF-8";
 
     nix = {
-      package = pkgs.nixVersions.nix_2_21;
+      package = pkgs.nixVersions.nix_2_30;
       channel.enable = false; # opt out of nix channels
       settings = {
         experimental-features = [

--- a/nixos-modules/fonts.nix
+++ b/nixos-modules/fonts.nix
@@ -28,7 +28,7 @@ in
           pkgs.noto-fonts
           pkgs.noto-fonts-cjk-sans
           pkgs.noto-fonts-color-emoji
-          pkgs.nerdfonts
+          # pkgs.nerdfonts
         ];
         defaultText = literalExpression ''
           [

--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -14,7 +14,7 @@ inputs: {
 
     composeManyExtensions [
 
-      inputs.nur.overlay
+      inputs.nur.overlays.default
 
       # auto-add packages
       (final: prev: {


### PR DESCRIPTION
- **flake-inputs: add nixpkgs 25.05, add home-manager 25.05, add nixpkgs-lib**
- **flake.nix: clean up outputs expression**
- **tree-wide: 25.05 modules upgrade**
- **treewide: update audio/bluetooth modules and configurations**
- **home-modules.djacu.dev: add gh and zathura**
