### PR TITLE
treewide: nixpkgs upgrade

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -1,0 +1,33 @@
+name: pull request checks
+on:
+  pull_request:
+  push: # This is only run when PRs are merged into master
+    branches:
+      - master
+  workflow_dispatch:
+jobs:
+  nix-checks:
+    name: nix flake check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: DeterminateSystems/nix-installer-action@main
+      - uses: DeterminateSystems/magic-nix-cache-action@main
+      - run: nix flake check -L
+        # monitor and bind-master uses IFD
+  nix-verify-hydra-system-configs:
+    name: nix verify nixos configurations
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: DeterminateSystems/nix-installer-action@main
+      - uses: DeterminateSystems/magic-nix-cache-action@main
+      - run: nix run .#theonecfg.verify-hydra-system-configs
+  nix-verify-hydra-home-configs:
+    name: nix verify home configurations
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: DeterminateSystems/nix-installer-action@main
+      - uses: DeterminateSystems/magic-nix-cache-action@main
+      - run: nix run .#theonecfg.verify-hydra-home-configs

--- a/flake.lock
+++ b/flake.lock
@@ -208,16 +208,16 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1771207753,
-        "narHash": "sha256-b9uG8yN50DRQ6A7JdZBfzq718ryYrlmGgqkRm9OOwCE=",
+        "lastModified": 1771369470,
+        "narHash": "sha256-0NBlEBKkN3lufyvFegY4TYv5mCNHbi5OmBDrzihbBMQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "d1c15b7d5806069da59e819999d70e1cec0760bf",
+        "rev": "0182a361324364ae3f436a63005877674cf45efb",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixpkgs-unstable",
+        "ref": "nixos-unstable",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.lock
+++ b/flake.lock
@@ -7,11 +7,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1753140376,
-        "narHash": "sha256-7lrVrE0jSvZHrxEzvnfHFE/Wkk9DDqb+mYCodI5uuB8=",
+        "lastModified": 1771469470,
+        "narHash": "sha256-GnqdqhrguKNN3HtVfl6z+zbV9R9jhHFm3Z8nu7R6ml0=",
         "owner": "nix-community",
         "repo": "disko",
-        "rev": "545aba02960caa78a31bd9a8709a0ad4b6320a5c",
+        "rev": "4707eec8d1d2db5182ea06ed48c820a86a42dc13",
         "type": "github"
       },
       "original": {
@@ -63,34 +63,59 @@
         "type": "github"
       }
     },
-    "home-manager-2505": {
+    "home-manager": {
       "inputs": {
         "nixpkgs": [
-          "nixpkgs-2505"
+          "impermanence",
+          "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1756245065,
-        "narHash": "sha256-aAZNbGcWrVRZgWgkQbkabSGcDVRDMgON4BipMy69gvI=",
+        "lastModified": 1768598210,
+        "narHash": "sha256-kkgA32s/f4jaa4UG+2f8C225Qvclxnqs76mf8zvTVPg=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "54b2879ce622d44415e727905925e21b8f833a98",
+        "rev": "c47b2cc64a629f8e075de52e4742de688f930dc6",
         "type": "github"
       },
       "original": {
         "owner": "nix-community",
-        "ref": "release-25.05",
+        "repo": "home-manager",
+        "type": "github"
+      }
+    },
+    "home-manager-2511": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs-2511"
+        ]
+      },
+      "locked": {
+        "lastModified": 1770260404,
+        "narHash": "sha256-3iVX1+7YUIt23hBx1WZsUllhbmP2EnXrV8tCRbLxHc8=",
+        "owner": "nix-community",
+        "repo": "home-manager",
+        "rev": "0d782ee42c86b196acff08acfbf41bb7d13eed5b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "ref": "release-25.11",
         "repo": "home-manager",
         "type": "github"
       }
     },
     "impermanence": {
+      "inputs": {
+        "home-manager": "home-manager",
+        "nixpkgs": "nixpkgs"
+      },
       "locked": {
-        "lastModified": 1737831083,
-        "narHash": "sha256-LJggUHbpyeDvNagTUrdhe/pRVp4pnS6wVKALS782gRI=",
+        "lastModified": 1769548169,
+        "narHash": "sha256-03+JxvzmfwRu+5JafM0DLbxgHttOQZkUtDWBmeUkN8Y=",
         "owner": "nix-community",
         "repo": "impermanence",
-        "rev": "4b3e914cdf97a5b536a889e939fb2fd2b043a170",
+        "rev": "7b1d382faf603b6d264f58627330f9faa5cba149",
         "type": "github"
       },
       "original": {
@@ -101,11 +126,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1754564048,
-        "narHash": "sha256-dz303vGuzWjzOPOaYkS9xSW+B93PSAJxvBd6CambXVA=",
+        "lastModified": 1771423359,
+        "narHash": "sha256-yRKJ7gpVmXbX2ZcA8nFi6CMPkJXZGjie2unsiMzj3Ig=",
         "owner": "nixos",
         "repo": "nixos-hardware",
-        "rev": "26ed7a0d4b8741fe1ef1ee6fa64453ca056ce113",
+        "rev": "740a22363033e9f1bb6270fbfb5a9574067af15b",
         "type": "github"
       },
       "original": {
@@ -115,6 +140,69 @@
       }
     },
     "nixpkgs": {
+      "locked": {
+        "lastModified": 1768564909,
+        "narHash": "sha256-Kell/SpJYVkHWMvnhqJz/8DqQg2b6PguxVWOuadbHCc=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "e4bae1bd10c9c57b2cf517953ab70060a828ee6f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-2511": {
+      "locked": {
+        "lastModified": 1771574726,
+        "narHash": "sha256-D1PA3xQv/s4W3lnR9yJFSld8UOLr0a/cBWMQMXS+1Qg=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "c217913993d6c6f6805c3b1a3bda5e639adfde6d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-25.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-lib": {
+      "locked": {
+        "lastModified": 1771119037,
+        "narHash": "sha256-OAOcOMYrZwP1DS6sxGKNXdJjsTq+UtZiouBdW4X7LX8=",
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "rev": "f472c854add422e3723c6fee2a470bbbec434006",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "type": "github"
+      }
+    },
+    "nixpkgs-unstable": {
+      "locked": {
+        "lastModified": 1771207753,
+        "narHash": "sha256-b9uG8yN50DRQ6A7JdZBfzq718ryYrlmGgqkRm9OOwCE=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "d1c15b7d5806069da59e819999d70e1cec0760bf",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_2": {
       "locked": {
         "lastModified": 1761440988,
         "narHash": "sha256-2qsow3cQIgZB2g8Cy8cW+L9eXDHP6a1PsvOschk5y+E=",
@@ -130,60 +218,13 @@
         "type": "github"
       }
     },
-    "nixpkgs-2505": {
+    "nixpkgs_3": {
       "locked": {
-        "lastModified": 1756217674,
-        "narHash": "sha256-TH1SfSP523QI7kcPiNtMAEuwZR3Jdz0MCDXPs7TS8uo=",
+        "lastModified": 1771369470,
+        "narHash": "sha256-0NBlEBKkN3lufyvFegY4TYv5mCNHbi5OmBDrzihbBMQ=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "4e7667a90c167f7a81d906e5a75cba4ad8bee620",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nixos",
-        "ref": "nixos-25.05",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs-lib": {
-      "locked": {
-        "lastModified": 1762045811,
-        "narHash": "sha256-ObaNaUu4Ey117f3UWMQL7CN/QBEUPM9MiwGSG9piCL0=",
-        "owner": "nix-community",
-        "repo": "nixpkgs.lib",
-        "rev": "e171c13eb1bfa148a2e5ed435768d5e89e235d0f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-community",
-        "repo": "nixpkgs.lib",
-        "type": "github"
-      }
-    },
-    "nixpkgs-unstable": {
-      "locked": {
-        "lastModified": 1762156382,
-        "narHash": "sha256-Yg7Ag7ov5+36jEFC1DaZh/12SEXo6OO3/8rqADRxiqs=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "7241bcbb4f099a66aafca120d37c65e8dda32717",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixpkgs-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_2": {
-      "locked": {
-        "lastModified": 1754725699,
-        "narHash": "sha256-iAcj9T/Y+3DBy2J0N+yF9XQQQ8IEb5swLFzs23CdP88=",
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "85dbfc7aaf52ecb755f87e577ddbe6dbbdbc1054",
+        "rev": "0182a361324364ae3f436a63005877674cf45efb",
         "type": "github"
       },
       "original": {
@@ -196,7 +237,7 @@
     "nixvim": {
       "inputs": {
         "flake-parts": "flake-parts",
-        "nixpkgs": "nixpkgs",
+        "nixpkgs": "nixpkgs_2",
         "nuschtosSearch": [
           "nixvimcfg"
         ],
@@ -253,14 +294,14 @@
     "nur": {
       "inputs": {
         "flake-parts": "flake-parts_2",
-        "nixpkgs": "nixpkgs_2"
+        "nixpkgs": "nixpkgs_3"
       },
       "locked": {
-        "lastModified": 1754796447,
-        "narHash": "sha256-Nr9VQAQNRMS1KdMff8pjQKzKhLeTQMU5tYRTAoJn2HI=",
+        "lastModified": 1771703018,
+        "narHash": "sha256-U4bP8N/by+feH+v79jd5l6ZJXK886xd5zxmDm8NL+A8=",
         "owner": "nix-community",
         "repo": "nur",
-        "rev": "49b376f0dfde378efa30fa99536dd87792e4d91f",
+        "rev": "a5c0f147156cd4e4c3292c8545196ca0094b333c",
         "type": "github"
       },
       "original": {
@@ -272,10 +313,10 @@
     "root": {
       "inputs": {
         "disko": "disko",
-        "home-manager-2505": "home-manager-2505",
+        "home-manager-2511": "home-manager-2511",
         "impermanence": "impermanence",
         "nixos-hardware": "nixos-hardware",
-        "nixpkgs-2505": "nixpkgs-2505",
+        "nixpkgs-2511": "nixpkgs-2511",
         "nixpkgs-lib": "nixpkgs-lib",
         "nixpkgs-unstable": "nixpkgs-unstable",
         "nixvimcfg": "nixvimcfg",
@@ -326,11 +367,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1761311587,
-        "narHash": "sha256-Msq86cR5SjozQGCnC6H8C+0cD4rnx91BPltZ9KK613Y=",
+        "lastModified": 1770228511,
+        "narHash": "sha256-wQ6NJSuFqAEmIg2VMnLdCnUc0b7vslUohqqGGD+Fyxk=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "2eddae033e4e74bf581c2d1dfa101f9033dbd2dc",
+        "rev": "337a4fe074be1042a35086f15481d763b8ddc0e7",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -105,6 +105,26 @@
         "type": "github"
       }
     },
+    "home-manager-unstable": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs-unstable"
+        ]
+      },
+      "locked": {
+        "lastModified": 1771683283,
+        "narHash": "sha256-WxAEkAbo8dP7qiyPM6VN4ZGAxfuBVlNBNPkrqkrXVEc=",
+        "owner": "nix-community",
+        "repo": "home-manager",
+        "rev": "c6ed3eab64d23520bcbb858aa53fe2b533725d4a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "home-manager",
+        "type": "github"
+      }
+    },
     "impermanence": {
       "inputs": {
         "home-manager": "home-manager",
@@ -314,6 +334,7 @@
       "inputs": {
         "disko": "disko",
         "home-manager-2511": "home-manager-2511",
+        "home-manager-unstable": "home-manager-unstable",
         "impermanence": "impermanence",
         "nixos-hardware": "nixos-hardware",
         "nixpkgs-2511": "nixpkgs-2511",

--- a/flake.nix
+++ b/flake.nix
@@ -4,6 +4,8 @@
     disko.inputs.nixpkgs.follows = "nixpkgs-unstable";
     home-manager-2511.url = "github:nix-community/home-manager/release-25.11";
     home-manager-2511.inputs.nixpkgs.follows = "nixpkgs-2511";
+    home-manager-unstable.url = "github:nix-community/home-manager";
+    home-manager-unstable.inputs.nixpkgs.follows = "nixpkgs-unstable";
     impermanence.url = "github:nix-community/impermanence";
     nixpkgs-lib.url = "github:nix-community/nixpkgs.lib";
     nixpkgs-2511.url = "github:nixos/nixpkgs/nixos-25.11";

--- a/flake.nix
+++ b/flake.nix
@@ -9,7 +9,7 @@
     impermanence.url = "github:nix-community/impermanence";
     nixpkgs-lib.url = "github:nix-community/nixpkgs.lib";
     nixpkgs-2511.url = "github:nixos/nixpkgs/nixos-25.11";
-    nixpkgs-unstable.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+    nixpkgs-unstable.url = "github:NixOS/nixpkgs/nixos-unstable";
     nixos-hardware.url = "github:nixos/nixos-hardware";
     nixvimcfg.url = "github:djacu/nixvimcfg";
     nur.url = "github:nix-community/nur";

--- a/flake.nix
+++ b/flake.nix
@@ -2,11 +2,11 @@
   inputs = {
     disko.url = "github:nix-community/disko/";
     disko.inputs.nixpkgs.follows = "nixpkgs-unstable";
-    home-manager-2505.url = "github:nix-community/home-manager/release-25.05";
-    home-manager-2505.inputs.nixpkgs.follows = "nixpkgs-2505";
+    home-manager-2511.url = "github:nix-community/home-manager/release-25.11";
+    home-manager-2511.inputs.nixpkgs.follows = "nixpkgs-2511";
     impermanence.url = "github:nix-community/impermanence";
     nixpkgs-lib.url = "github:nix-community/nixpkgs.lib";
-    nixpkgs-2505.url = "github:nixos/nixpkgs/nixos-25.05";
+    nixpkgs-2511.url = "github:nixos/nixpkgs/nixos-25.11";
     nixpkgs-unstable.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
     nixos-hardware.url = "github:nixos/nixos-hardware";
     nixvimcfg.url = "github:djacu/nixvimcfg";

--- a/flake.nix
+++ b/flake.nix
@@ -23,6 +23,7 @@
     formatterModule = import ./formatter-module inputs;
     homeConfigurations = import ./home-configurations inputs;
     homeModules = import ./home-modules inputs;
+    hydraJobs = import ./hydra-jobs inputs;
     legacyPackages = import ./legacy-packages inputs;
     library = import ./library inputs;
     nixosConfigurations = import ./nixos-configurations inputs;

--- a/home-configurations/argentite/djacu/default.nix
+++ b/home-configurations/argentite/djacu/default.nix
@@ -1,7 +1,7 @@
 inputs: {
   system = "x86_64-linux";
   release = rec {
-    number = "2511";
+    number = "unstable";
     nixpkgs = inputs."nixpkgs-${number}";
     home-manager = inputs."home-manager-${number}";
   };

--- a/home-configurations/argentite/djacu/default.nix
+++ b/home-configurations/argentite/djacu/default.nix
@@ -1,7 +1,7 @@
 inputs: {
   system = "x86_64-linux";
   release = rec {
-    number = "2505";
+    number = "2511";
     nixpkgs = inputs."nixpkgs-${number}";
     home-manager = inputs."home-manager-${number}";
   };

--- a/home-configurations/cassiterite/djacu/default.nix
+++ b/home-configurations/cassiterite/djacu/default.nix
@@ -1,7 +1,7 @@
 inputs: {
   system = "x86_64-linux";
   release = rec {
-    number = "2511";
+    number = "unstable";
     nixpkgs = inputs."nixpkgs-${number}";
     home-manager = inputs."home-manager-${number}";
   };

--- a/home-configurations/cassiterite/djacu/default.nix
+++ b/home-configurations/cassiterite/djacu/default.nix
@@ -1,7 +1,7 @@
 inputs: {
   system = "x86_64-linux";
   release = rec {
-    number = "2505";
+    number = "2511";
     nixpkgs = inputs."nixpkgs-${number}";
     home-manager = inputs."home-manager-${number}";
   };

--- a/home-configurations/malachite/djacu/default.nix
+++ b/home-configurations/malachite/djacu/default.nix
@@ -1,7 +1,7 @@
 inputs: {
   system = "x86_64-linux";
   release = rec {
-    number = "2511";
+    number = "unstable";
     nixpkgs = inputs."nixpkgs-${number}";
     home-manager = inputs."home-manager-${number}";
   };

--- a/home-configurations/malachite/djacu/default.nix
+++ b/home-configurations/malachite/djacu/default.nix
@@ -1,7 +1,7 @@
 inputs: {
   system = "x86_64-linux";
   release = rec {
-    number = "2505";
+    number = "2511";
     nixpkgs = inputs."nixpkgs-${number}";
     home-manager = inputs."home-manager-${number}";
   };

--- a/home-configurations/scheelite/djacu/default.nix
+++ b/home-configurations/scheelite/djacu/default.nix
@@ -1,7 +1,7 @@
 inputs: {
   system = "x86_64-linux";
   release = rec {
-    number = "2511";
+    number = "unstable";
     nixpkgs = inputs."nixpkgs-${number}";
     home-manager = inputs."home-manager-${number}";
   };

--- a/home-configurations/scheelite/djacu/default.nix
+++ b/home-configurations/scheelite/djacu/default.nix
@@ -1,7 +1,7 @@
 inputs: {
   system = "x86_64-linux";
   release = rec {
-    number = "2505";
+    number = "2511";
     nixpkgs = inputs."nixpkgs-${number}";
     home-manager = inputs."home-manager-${number}";
   };

--- a/home-modules/packages/messaging/module.nix
+++ b/home-modules/packages/messaging/module.nix
@@ -28,7 +28,7 @@ in
       pkgs.discord
       pkgs.element-desktop
       pkgs.signal-desktop
-      pkgs.whatsapp-for-linux
+      pkgs.wasistlos
 
     ];
 

--- a/home-modules/packages/networking/module.nix
+++ b/home-modules/packages/networking/module.nix
@@ -24,7 +24,6 @@ in
   config = mkIf cfg.enable {
     home.packages = [
 
-      pkgs.dig
       pkgs.dnsutils
       pkgs.iputils
       pkgs.traceroute

--- a/home-modules/users/djacu/programs/git/module.nix
+++ b/home-modules/users/djacu/programs/git/module.nix
@@ -33,6 +33,7 @@ in
         merge.conflictstyle = "zdiff3";
         rerere.enabled = true;
       };
+      lfs.enable = true;
     };
   };
 }

--- a/home-modules/users/djacu/programs/git/module.nix
+++ b/home-modules/users/djacu/programs/git/module.nix
@@ -11,8 +11,10 @@ in
       userName = "Daniel Baker";
       userEmail = "dan@djacu.dev";
       aliases = {
+        amend = "commit --amend --no-edit";
         lg = "log --graph --decorate --pretty=oneline --abbrev-commit --all";
         patch = "diff --no-ext-diff";
+        reuse = "commit -C ORIG_HEAD";
       };
       difftastic.enable = true;
       difftastic.background = "dark";

--- a/home-modules/users/djacu/programs/git/module.nix
+++ b/home-modules/users/djacu/programs/git/module.nix
@@ -6,24 +6,26 @@ in
   options.theonecfg.users.djacu.programs.git.enable = lib.mkEnableOption "djacu git config";
 
   config = lib.mkIf (cfg.enable && cfg.programs.git.enable) {
+
+    programs.difftastic = {
+      enable = true;
+      git.enable = true;
+      options.background = "dark";
+      options.color = "always";
+    };
+
     programs.git = {
       enable = true;
-      userName = "Daniel Baker";
-      userEmail = "dan@djacu.dev";
-      aliases = {
-        amend = "commit --amend --no-edit";
-        lg = "log --graph --decorate --pretty=oneline --abbrev-commit --all";
-        patch = "diff --no-ext-diff";
-        reuse = "commit -C ORIG_HEAD";
-      };
-      difftastic.enable = true;
-      difftastic.background = "dark";
-      difftastic.color = "always";
       ignores = [
         "*.swp"
         "result*"
       ];
-      extraConfig = {
+      lfs.enable = true;
+      settings = {
+        alias.amend = "commit --amend --no-edit";
+        alias.lg = "log --graph --decorate --pretty=oneline --abbrev-commit --all";
+        alias.patch = "diff --no-ext-diff";
+        alias.reuse = "commit -C ORIG_HEAD";
         blame.ignoreRevsFile = ".git-blame-ignore-revs";
         core.editor = "nvim";
         diff.algorithm = "histogram";
@@ -32,8 +34,10 @@ in
         init.defaultBranch = "main";
         merge.conflictstyle = "zdiff3";
         rerere.enabled = true;
+        user.email = "dan@djacu.dev";
+        user.name = "Daniel Baker";
       };
-      lfs.enable = true;
     };
+
   };
 }

--- a/home-modules/users/djacu/programs/gpg/module.nix
+++ b/home-modules/users/djacu/programs/gpg/module.nix
@@ -138,19 +138,22 @@ in
 
       programs.ssh.enable = true;
       # https://nix-community.github.io/home-manager/options.xhtml#opt-programs.ssh.enableDefaultConfig
-      # programs.ssh.matchBlocks."*" = {
-      #   forwardAgent = false;
-      #   addKeysToAgent = "no";
-      #   compression = false;
-      #   serverAliveInterval = 0;
-      #   serverAliveCountMax = 3;
-      #   hashKnownHosts = false;
-      #   userKnownHostsFile = "~/.ssh/known_hosts";
-      #   controlMaster = "no";
-      #   controlPath = "~/.ssh/master-%r@%n:%p";
-      #   controlPersist = "no";
-      # };
-      programs.ssh.matchBlocks = mkHostMatchBlock forwardedHosts;
+      programs.ssh.enableDefaultConfig = false;
+      programs.ssh.matchBlocks = {
+        "*" = {
+          forwardAgent = false;
+          addKeysToAgent = "no";
+          compression = false;
+          serverAliveInterval = 0;
+          serverAliveCountMax = 3;
+          hashKnownHosts = false;
+          userKnownHostsFile = "~/.ssh/known_hosts";
+          controlMaster = "no";
+          controlPath = "~/.ssh/master-%r@%n:%p";
+          controlPersist = "no";
+        };
+      }
+      // (mkHostMatchBlock forwardedHosts);
 
     })
 

--- a/home-modules/users/djacu/programs/gpg/module.nix
+++ b/home-modules/users/djacu/programs/gpg/module.nix
@@ -157,7 +157,7 @@ in
     (mkIf cfgGitIntegration.enable {
 
       programs.git = {
-        extraConfig = {
+        settings = {
           # gpg
           commit.gpgsign = true;
           tag.gpgSign = true;

--- a/hydra-jobs/default.nix
+++ b/hydra-jobs/default.nix
@@ -45,6 +45,13 @@ in
 
 {
 
+  homeConfigs = defaultSystems (
+    system:
+    mapAttrs (const (value: value.activation-script)) (
+      filterAttrs (const (value: value.config.nixpkgs.system == system)) inputs.self.homeConfigurations
+    )
+  );
+
   systemConfigs = defaultSystems (
     system:
     mapAttrs

--- a/hydra-jobs/default.nix
+++ b/hydra-jobs/default.nix
@@ -1,0 +1,83 @@
+inputs:
+let
+
+  # inherits
+
+  inherit (inputs.self)
+    library
+    theonecfg
+    ;
+
+  inherit (library.systems)
+    defaultSystems
+    ;
+
+  inherit (theonecfg)
+    knownHosts
+    ;
+
+  inherit (builtins)
+    throw
+    ;
+
+  inherit (inputs.nixpkgs-lib)
+    lib
+    ;
+
+  inherit (lib.attrsets)
+    filterAttrs
+    mapAttrs
+    ;
+
+  inherit (lib.customisation)
+    hydraJob
+    ;
+
+  inherit (lib.lists)
+    elem
+    ;
+
+  inherit (lib.trivial)
+    const
+    ;
+
+in
+
+{
+
+  systemConfigs = defaultSystems (
+    system:
+    mapAttrs
+      (
+        name: value:
+        let
+          type = knownHosts.${name}.type;
+          elemType = elem type;
+        in
+        hydraJob (
+          if
+            elemType [
+              "desktop"
+              "laptop"
+              "server"
+            ]
+          then
+            value.config.system.build.toplevel
+          else if
+            elemType [
+              "virtual"
+            ]
+          then
+            value.config.system.build.vm
+          else
+            throw "NixOS configuration '${name}' has an unknown type '${type}'."
+        )
+      )
+      (
+        filterAttrs (const (
+          value: value.config.nixpkgs.buildPlatform.system == system
+        )) inputs.self.nixosConfigurations
+      )
+  );
+
+}

--- a/legacy-packages/default.nix
+++ b/legacy-packages/default.nix
@@ -1,13 +1,8 @@
 inputs:
-inputs.nixpkgs-lib.lib.genAttrs
-  [
-    "x86_64-linux"
-    "aarch64-linux"
-  ]
-  (
-    system:
-    import inputs.nixpkgs-unstable {
-      inherit system;
-      overlays = [ inputs.self.overlays.default ];
-    }
-  )
+inputs.self.library.systems.defaultSystems (
+  system:
+  import inputs.nixpkgs-unstable {
+    inherit system;
+    overlays = [ inputs.self.overlays.default ];
+  }
+)

--- a/library/default.nix
+++ b/library/default.nix
@@ -44,6 +44,15 @@ let
 in
 fix (finalLibrary: {
 
+  systems = {
+
+    defaultSystems = genAttrs [
+      "x86_64-linux"
+      "aarch64-linux"
+    ];
+
+  };
+
   path = fix (finalPath: {
 
     /**

--- a/nixos-configurations/argentite/default.nix
+++ b/nixos-configurations/argentite/default.nix
@@ -1,6 +1,6 @@
 inputs: {
   release = rec {
-    number = "2505";
+    number = "2511";
     nixpkgs = inputs."nixpkgs-${number}";
   };
   modules =
@@ -20,7 +20,7 @@ inputs: {
         nixpkgs.hostPlatform = "x86_64-linux";
         system.stateVersion = "25.05";
 
-        boot.kernelPackages = pkgs.linuxPackages_6_15;
+        boot.kernelPackages = pkgs.linuxPackages_6_18;
         boot.loader.systemd-boot.enable = true;
         boot.loader.efi.canTouchEfiVariables = true;
         boot.loader.efi.efiSysMountPoint = "/boot";

--- a/nixos-configurations/argentite/default.nix
+++ b/nixos-configurations/argentite/default.nix
@@ -1,6 +1,6 @@
 inputs: {
   release = rec {
-    number = "2511";
+    number = "unstable";
     nixpkgs = inputs."nixpkgs-${number}";
   };
   modules =

--- a/nixos-configurations/cassiterite/default.nix
+++ b/nixos-configurations/cassiterite/default.nix
@@ -1,6 +1,6 @@
 inputs: {
   release = rec {
-    number = "2505";
+    number = "2511";
     nixpkgs = inputs."nixpkgs-${number}";
   };
   modules =
@@ -21,7 +21,7 @@ inputs: {
         nixpkgs.hostPlatform = "x86_64-linux";
         system.stateVersion = "24.05";
 
-        boot.kernelPackages = pkgs.linuxPackages_6_15;
+        boot.kernelPackages = pkgs.linuxPackages_6_18;
         boot.loader.systemd-boot.enable = true;
         boot.loader.efi.canTouchEfiVariables = true;
         boot.loader.efi.efiSysMountPoint = "/boot";

--- a/nixos-configurations/cassiterite/default.nix
+++ b/nixos-configurations/cassiterite/default.nix
@@ -1,6 +1,6 @@
 inputs: {
   release = rec {
-    number = "2511";
+    number = "unstable";
     nixpkgs = inputs."nixpkgs-${number}";
   };
   modules =

--- a/nixos-configurations/malachite/default.nix
+++ b/nixos-configurations/malachite/default.nix
@@ -1,6 +1,6 @@
 inputs: {
   release = rec {
-    number = "2505";
+    number = "2511";
     nixpkgs = inputs."nixpkgs-${number}";
   };
   modules =
@@ -23,7 +23,7 @@ inputs: {
         nixpkgs.hostPlatform = "x86_64-linux";
         system.stateVersion = "24.05";
 
-        boot.kernelPackages = pkgs.linuxPackages_6_15;
+        boot.kernelPackages = pkgs.linuxPackages_6_18;
         boot.loader.systemd-boot.enable = true;
         boot.loader.efi.canTouchEfiVariables = true;
         boot.loader.efi.efiSysMountPoint = "/boot";

--- a/nixos-configurations/malachite/default.nix
+++ b/nixos-configurations/malachite/default.nix
@@ -1,6 +1,6 @@
 inputs: {
   release = rec {
-    number = "2511";
+    number = "unstable";
     nixpkgs = inputs."nixpkgs-${number}";
   };
   modules =

--- a/nixos-configurations/scheelite/default.nix
+++ b/nixos-configurations/scheelite/default.nix
@@ -1,6 +1,6 @@
 inputs: {
   release = rec {
-    number = "2505";
+    number = "2511";
     nixpkgs = inputs."nixpkgs-${number}";
   };
   modules =
@@ -25,7 +25,7 @@ inputs: {
         boot.loader.efi.efiSysMountPoint = "/boot";
 
         # ZFS
-        boot.kernelPackages = pkgs.linuxPackages_6_15;
+        boot.kernelPackages = pkgs.linuxPackages_6_18;
         boot.supportedFilesystems = [ "zfs" ];
         boot.zfs.devNodes = "/dev/disk/by-id";
         boot.zfs.extraPools = [ "scheelite-tank0" ];

--- a/nixos-configurations/scheelite/default.nix
+++ b/nixos-configurations/scheelite/default.nix
@@ -1,6 +1,6 @@
 inputs: {
   release = rec {
-    number = "2511";
+    number = "unstable";
     nixpkgs = inputs."nixpkgs-${number}";
   };
   modules =

--- a/nixos-configurations/test-vm/default.nix
+++ b/nixos-configurations/test-vm/default.nix
@@ -1,6 +1,6 @@
 inputs: {
   release = rec {
-    number = "2505";
+    number = "2511";
     nixpkgs = inputs."nixpkgs-${number}";
   };
   modules =

--- a/nixos-configurations/test-vm/default.nix
+++ b/nixos-configurations/test-vm/default.nix
@@ -1,6 +1,6 @@
 inputs: {
   release = rec {
-    number = "2511";
+    number = "unstable";
     nixpkgs = inputs."nixpkgs-${number}";
   };
   modules =

--- a/package-sets/top-level/theonecfg/verify-hydra-home-configs/package.nix
+++ b/package-sets/top-level/theonecfg/verify-hydra-home-configs/package.nix
@@ -1,0 +1,26 @@
+{
+  jq,
+  nix-eval-jobs,
+  nix-output-monitor,
+  stdenv,
+  writeShellApplication,
+}:
+writeShellApplication {
+
+  name = builtins.baseNameOf ./.;
+
+  runtimeInputs = [
+    jq
+    nix-eval-jobs
+    nix-output-monitor
+  ];
+
+  text = ''
+    nix-eval-jobs --flake .#hydraJobs.homeConfigs.${stdenv.hostPlatform.system} --constituents > jobs.json
+    jq -cr '.constituents + [.drvPath] | .[] | select(.!=null) + "^*"' <jobs.json | \
+    nom build --keep-going --no-link --print-out-paths --stdin "$@"
+    echo "These derivations failed to evaluate: $(jq -s 'map(select(.error != null)) | map(.attr)' <jobs.json)"
+    exit "$(jq -s 'map(select(.error != null)) | [length, 1] | min' <jobs.json)"
+  '';
+
+}

--- a/package-sets/top-level/theonecfg/verify-hydra-system-configs/package.nix
+++ b/package-sets/top-level/theonecfg/verify-hydra-system-configs/package.nix
@@ -1,0 +1,26 @@
+{
+  jq,
+  nix-eval-jobs,
+  nix-output-monitor,
+  stdenv,
+  writeShellApplication,
+}:
+writeShellApplication {
+
+  name = builtins.baseNameOf ./.;
+
+  runtimeInputs = [
+    jq
+    nix-eval-jobs
+    nix-output-monitor
+  ];
+
+  text = ''
+    nix-eval-jobs --flake .#hydraJobs.systemConfigs.${stdenv.hostPlatform.system} --constituents > jobs.json
+    jq -cr '.constituents + [.drvPath] | .[] | select(.!=null) + "^*"' <jobs.json | \
+    nom build --keep-going --no-link --print-out-paths --stdin "$@"
+    echo "These derivations failed to evaluate: $(jq -s 'map(select(.error != null)) | map(.attr)' <jobs.json)"
+    exit "$(jq -s 'map(select(.error != null)) | [length, 1] | min' <jobs.json)"
+  '';
+
+}


### PR DESCRIPTION
- **flake.inputs: 25.05 -> 25.11**
- **{home,nixos}-configurations: update to 25.11**
- **flake.inputs: home manager unstable add**
- **{home,nixos}-configurations: update to unstable**
- **homeModules.packages.messaging: 'whatsapp-for-linux' has been renamed to/replaced by 'wasistlos'**
- **homeModules.users.djacu.programs.git: add amend and reuse aliases**
- **homeModules.users.djacu.programs.git: enable git lfs**
- **flake.inputs: nixpkgs-unstable tracks nixos-unstable now**
- **homeModules.users.djacu.programs.{git,gpg}: update git configuration**
- **homeModules.users.djacu.programs.gpg: don't use default ssh config**
- **library: add systems.defaultSystems**
- **legacyPackages: use systems.defaultSystems**
- **hydraJobs: init with systemConfigs job**
- **theonecfg.verify-hydra-system-configs: init**
- **homeModules.packages.networking: remove dig**
- **hydraJobs.homeConfigs: init**
- **theonecfg.verify-hydra-home-configs: init**
- **.github/workflows/pull-request.yml: init**
